### PR TITLE
fixed bitrotted link

### DIFF
--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -156,7 +156,7 @@
         <p>
             Maps and data by
             <a href="https://openstreetmap.org">OpenStreetMap</a>,
-            <a href="https://tinyworldmap.com">tinyworldmap</a> and
+            <a href="https://github.com/tinyworldmap/tiny-world-map">tinyworldmap</a> and
             <a href="https://hitchwiki.org">HitchWiki</a>
         </p>
         <h4>License</h4>


### PR DESCRIPTION
The tinyworldmap.com link in the "Credits" section of the site has bitrotten so it was replaced with a link to the github page.
Alternatively, we could point to <https://web.archive.org/web/20250409134704/http://tinyworldmap.com/> which seems to be the last useful archive of the website. In my experience, clicking a link and automatically going to an archive.org time machine link sucks though because of how slow the service tends to be.